### PR TITLE
Bug fixes and feature additions for VSC Interlis Extension

### DIFF
--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer.Test/Visitors/DiagramDocumentVisitorTest.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer.Test/Visitors/DiagramDocumentVisitorTest.cs
@@ -72,8 +72,8 @@ public class DiagramDocumentVisitorTests
 
         var diagram = BuildDiagram(ili);
 
-        // fixed size list (2) must render the  ×2 suffix
-        StringAssert.Contains(diagram, "exactlyTwoRef #colon; **B ×2**");
+        // fixed size list (2) must render the [2] suffix
+        StringAssert.Contains(diagram, "exactlyTwoRef[2] #colon; **B**");
     }
 
     // ─── inheritance ───────────────────────────────────────────────────────────

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer.Test/Visitors/DiagramDocumentVisitorTest.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer.Test/Visitors/DiagramDocumentVisitorTest.cs
@@ -16,9 +16,6 @@ public class DiagramDocumentVisitorTests
         return visitor.GetDiagramDocument().ReplaceLineEndings("\n");
     }
 
-    private static Regex Line(string pattern) =>
-        new($"^{Regex.Escape(pattern)}$", RegexOptions.Multiline);
-
     // ─── basic cases ────────────────────────────────────────────────────────────
     [TestMethod]
     public void SingleClass_InTopic_ProducesNamespaceAndClass()

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer.Test/Visitors/DiagramDocumentVisitorTest.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer.Test/Visitors/DiagramDocumentVisitorTest.cs
@@ -1,10 +1,7 @@
-using System.Text;
-using System.Text.RegularExpressions;
 using Geowerkstatt.Interlis.Tools;
-using Geowerkstatt.Interlis.LanguageServer.Visitors;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace DiagramVisitor.Tests;
+namespace Geowerkstatt.Interlis.LanguageServer.Visitors;
 
 [TestClass]
 public class DiagramDocumentVisitorTests

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer.Test/Visitors/DiagramDocumentVisitorTest.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer.Test/Visitors/DiagramDocumentVisitorTest.cs
@@ -14,7 +14,7 @@ public class DiagramDocumentVisitorTests
     {
         var reader  = new InterlisReader();
         var ast     = reader.ReadFile(new StringReader(ili));
-        var visitor = new DiagramDocumentVisitor(NullLogger<DiagramDocumentVisitor>.Instance);
+        var visitor = new DiagramDocumentVisitor(NullLogger<DiagramDocumentVisitor>.Instance, "LR");
         visitor.VisitInterlisFile(ast);
         return visitor.GetDiagramDocument().ReplaceLineEndings("\n");
     }

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Handlers/GenerateDiagramHandler.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Handlers/GenerateDiagramHandler.cs
@@ -43,6 +43,7 @@ public class GenerateDiagramHandler : ExecuteTypedResponseCommandHandlerBase<Gen
         }
 
         var uri = options.Uri;
+        var orientation = options.Orientation;
         var fileContent = uri == null ? null : fileContentCache.GetBuffer(uri);
         if (string.IsNullOrEmpty(fileContent))
         {
@@ -53,14 +54,14 @@ public class GenerateDiagramHandler : ExecuteTypedResponseCommandHandlerBase<Gen
 
         using var stringReader = new StringReader(fileContent);
         var interlisFile = interlisReader.ReadFile(stringReader);
-        var diagram = GenerateDiagram(interlisFile);
+        var diagram = GenerateDiagram(interlisFile, orientation);
 
         return Task.FromResult<string?>(diagram);
     }
 
-    private string GenerateDiagram(InterlisFile interlisFile)
+    private string GenerateDiagram(InterlisFile interlisFile, String orientation)
     {
-        DiagramDocumentVisitor visitor = new DiagramDocumentVisitor(loggerFactory.CreateLogger<DiagramDocumentVisitor>());
+        DiagramDocumentVisitor visitor = new DiagramDocumentVisitor(loggerFactory.CreateLogger<DiagramDocumentVisitor>(), orientation);
         visitor.VisitInterlisFile(interlisFile);
         return visitor.GetDiagramDocument();
     }

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Handlers/GenerateDiagramOptions.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Handlers/GenerateDiagramOptions.cs
@@ -4,4 +4,4 @@ namespace Geowerkstatt.Interlis.LanguageServer.Handlers;
 /// Options for generating mermaid diagrams.
 /// </summary>
 /// <param name="Uri">The uri to identify the text document.</param>
-public record GenerateDiagramOptions(string? Uri);
+public record GenerateDiagramOptions(string? Uri, string Orientation);

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -286,4 +286,13 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
 
         return mermaidScript.ToString();
     }
+
+    internal static class MermaidConstants
+    {
+        public const string ClassStereotype = "**#60;#60;CLASS#62;#62;**#8203;";
+        public const string StructureStereotype = "**#60;#60;STRUCTURE#62;#62;**#8203;";
+        public const string Colon = "#colon;";
+        public const string LeftParenthesis = "#40;";
+        public const string RightParenthesis = "#41;";
+    }
 }

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -67,7 +67,7 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
     public override object? VisitAssociationDef([NotNull] AssociationDef associationDef)
     {
         associations.Add(associationDef);
-        return base.VisitAssociationDef(associationDef);
+        return DefaultResult;
     }
 
     private void AppendAttributeDetails(AttributeDef attributeDef)

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -12,18 +12,12 @@ namespace Geowerkstatt.Interlis.LanguageServer.Visitors;
 /// </summary>
 internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
 {
-    private readonly StringBuilder mermaidScript = new();
     private readonly List<ClassDef> classes = new();
+    private readonly List<ClassDef> structures = new();
     private readonly List<AssociationDef> associations = new();
-    private readonly ILogger<DiagramDocumentVisitor> logger;
+    private readonly StringBuilder mermaidScript = new();
 
-    private static readonly Dictionary<(long? Min, long? Max), string> MermaidCardinalityMap = new()
-    {
-        { (0, 1), "\"0..1\" " },
-        { (1, 1), "\"1\" " },
-        { (0, null), "\"*\"" },
-        { (1, null), "\"1..*\" " }
-    };
+    private readonly ILogger<DiagramDocumentVisitor> logger;
 
     public DiagramDocumentVisitor(ILogger<DiagramDocumentVisitor> logger)
     {

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -147,6 +147,27 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
         );
     }
 
+    private static string FormatNumericType(NumericType numericType)
+    {
+        string text;
+        if (numericType.Min != null && numericType.Max != null)
+        {
+            string minStr = numericType.Min.ToString()!;
+            string maxStr = numericType.Max.ToString()!;
+            text = $"{minStr}..{maxStr}";
+        }
+        else
+        {
+            text = "Numeric";
+        }
+
+        var unitName = numericType.Unit?.Target?.Name ?? numericType.Unit?.Path.LastOrDefault();
+        if (!string.IsNullOrEmpty(unitName))
+            text += $" [{unitName}]";
+
+        return text;
+    }
+
     private string VisitTypeDefInternal(TypeDef? type)
     {
         if (type == null) return "?";

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -254,50 +254,33 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
 
     public string GetDiagramDocument()
     {
-        foreach (var classDef in classes)
+        foreach (var type in classes.Concat(structures))
         {
-            if (classDef.Extends is { } extRef && extRef.Path.Any())
+            if (type.Extends is { } extRef && extRef.Path.Any())
             {
                 string parentSimple = extRef.Path.Last();
+                string parentLabel =
+                    extRef.Target != null ? parentSimple : $"`{parentSimple} #60;#60;EXTERNAL#62;#62;`";
 
-                string parentLabel = extRef.Target != null
-                    ? parentSimple
-                    : $"`{parentSimple} #60;#60;EXTERNAL#62;#62;`";
-
-                mermaidScript.AppendLine($"{classDef.Name} --|> {parentLabel}");
+                mermaidScript.AppendLine($"{type.Name} --|> {parentLabel}");
             }
 
-            if (classDef.MetaAttributes.TryGetValue("geow.uml.color", out var color) &&
-                !string.IsNullOrWhiteSpace(color))
+            if (type.MetaAttributes.TryGetValue("geow.uml.color", out var color) && !string.IsNullOrWhiteSpace(color))
             {
-                mermaidScript.AppendLine($"style {classDef.Name} fill:{color},color:black,stroke:black");
+                mermaidScript.AppendLine($"style {type.Name} fill:{color},color:black,stroke:black");
             }
 
-            mermaidScript.AppendLine(
-                $"{classDef.Name}: {MermaidConstants.ClassStereotype}"
-            );
+            var stereo = type.IsStructure ? MermaidConstants.StructureStereotype : MermaidConstants.ClassStereotype;
+            mermaidScript.AppendLine($"{type.Name}: {stereo}");
 
-            foreach (var attr in classDef.Content.Values.OfType<AttributeDef>())
-            {
-                AppendAttributeDetailsToScript(classDef, attr);
-            }
-
-            mermaidScript.AppendLine();
-        }
-
-        foreach (var structure in structures)
-        {
-            mermaidScript.AppendLine($"{structure.Name}: {MermaidConstants.StructureStereotype}");
-            foreach (var attr in structure.Content.Values.OfType<AttributeDef>())
-                AppendAttributeDetailsToScript(structure, attr);
+            foreach (var attr in type.Content.Values.OfType<AttributeDef>())
+                AppendAttributeDetailsToScript(type, attr);
 
             mermaidScript.AppendLine();
         }
 
         foreach (var associationDef in associations)
-        {
             AppendAssociationDetailsToScript(associationDef);
-        }
 
         mermaidScript.AppendLine();
 

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -22,6 +22,11 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
     public DiagramDocumentVisitor(ILogger<DiagramDocumentVisitor> logger)
     {
         this.logger = logger;
+        mermaidScript.AppendLine("---");
+        mermaidScript.AppendLine("  config:");
+        mermaidScript.AppendLine("    class:");
+        mermaidScript.AppendLine("      hideEmptyMembersBox: true");
+        mermaidScript.AppendLine("---");
         mermaidScript.AppendLine("classDiagram");
         mermaidScript.AppendLine("direction LR");
     }

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -19,7 +19,7 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
 
     private readonly ILogger<DiagramDocumentVisitor> logger;
 
-    public DiagramDocumentVisitor(ILogger<DiagramDocumentVisitor> logger)
+    public DiagramDocumentVisitor(ILogger<DiagramDocumentVisitor> logger, String orientation)
     {
         this.logger = logger;
         mermaidScript.AppendLine("---");
@@ -28,7 +28,7 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
         mermaidScript.AppendLine("      hideEmptyMembersBox: true");
         mermaidScript.AppendLine("---");
         mermaidScript.AppendLine("classDiagram");
-        mermaidScript.AppendLine("direction LR");
+        mermaidScript.AppendLine("direction " + orientation);
     }
 
     public override object? VisitTopicDef([NotNull] TopicDef topicDef)

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -174,16 +174,17 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
         return type switch
         {
             ReferenceType rt => rt.Target.Value?.Path.Last() ?? "?",
-            TextType tt => tt.Length == null ? "Text" : $"Text [{tt.Length}]",
-            NumericType nt => nt is { Min: not null, Max: not null } ? $"{nt.Min}..{nt.Max}" : "Numeric",
+            TextType tt => tt.Length is { } len ? $"Text[{len}]" : "Text",
+            NumericType nt => FormatNumericType(nt),
             BooleanType => "Boolean",
             BlackboxType bt => bt.Kind switch
             {
-                BlackboxType.BlackboxTypeKind.Binary => "Blackbox (Binary)",
-                BlackboxType.BlackboxTypeKind.Xml => "Blackbox (XML)",
+                BlackboxType.BlackboxTypeKind.Binary => "Blackbox(Binary)",
+                BlackboxType.BlackboxTypeKind.Xml => "Blackbox(XML)",
                 _ => "Blackbox"
             },
-            EnumerationType et => $"({FormatEnumerationValues(et.Values)})",
+            EnumerationType et =>
+                $"Enum{MermaidConstants.LeftParenthesis}{FormatEnumerationValues(et.Values)}{MermaidConstants.RightParenthesis}",
             TypeRef tr => tr.Extends?.Path.Last() ?? "?",
             RoleType => "Role",
             _ => type.GetType().Name

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -72,9 +72,20 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
 
     private void AppendAttributeDetailsToScript(ClassDef parentClass, AttributeDef attributeDef)
     {
-        var typeString = VisitTypeDefInternal(attributeDef.TypeDef) + CardinalitySuffix(attributeDef.TypeDef);
+        string bracket = "";
+        var card = attributeDef.TypeDef?.Cardinality;
+        if (card != null)
+        {
+            var min = card.Min ?? 0;
+            var max = card.Max ?? 0;
+            bracket = min == max
+                ? $"[{min}]"
+                : $"[{min}..{max}]";
+        }
+
+        var typeName = VisitTypeDefInternal(attributeDef.TypeDef);
         mermaidScript.AppendLine(
-            $"{parentClass.Name}: {attributeDef.Name} {MermaidConstants.Colon} **{typeString}**#8203;"
+            $"{parentClass.Name}: {attributeDef.Name}{bracket} {MermaidConstants.Colon} **{typeName}**#8203;"
         );
     }
 

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -33,35 +33,21 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
 
     public override object? VisitTopicDef([NotNull] TopicDef topicDef)
     {
+        int headerStart = mermaidScript.Length;
         mermaidScript.AppendLine($"namespace Topic_{topicDef.Name} {{");
+        int afterHeader = mermaidScript.Length;
         base.VisitTopicDef(topicDef);
-        mermaidScript.AppendLine("}");
-        mermaidScript.AppendLine();
+        bool hasContent = mermaidScript.Length > afterHeader;
 
-        foreach (var classDefs in classes)
+        if (hasContent)
         {
-            if (classDefs.Extends?.Target?.Name is string parent)
-                mermaidScript.AppendLine($"{classDefs.Name} --|> {parent}");
-
-            if (classDefs.MetaAttributes.TryGetValue("geow.uml.color", out var color) &&
-                !string.IsNullOrWhiteSpace(color))
-            {
-                mermaidScript.AppendLine($"style {classDefs.Name} fill:{color},color:black,stroke:black");
-            }
-
-            foreach (var attr in classDefs.Content.Values.OfType<AttributeDef>())
-                AppendAttributeDetails(attr);
-
+            mermaidScript.AppendLine("}");
             mermaidScript.AppendLine();
         }
-
-        foreach (var associationDef in associations)
-            AppendAssociationDetails(associationDef);
-
-        mermaidScript.AppendLine();
-
-        classes.Clear();
-        associations.Clear();
+        else
+        {
+            mermaidScript.Length = headerStart;
+        }
 
         return null;
     }

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -228,8 +228,7 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
         }
 
         var classDef = roleType.Targets.FirstOrDefault()?.Value?.Target as ClassDef;
-        var cardinalityTuple = (roleType.Cardinality.Min, roleType.Cardinality.Max);
-        MermaidCardinalityMap.TryGetValue(cardinalityTuple, out string? cardinality);
+        var cardinality = FormatCardinality(roleType.Cardinality);
         return (classDef, cardinality);
     }
 

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -55,9 +55,13 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
     public override object? VisitClassDef([NotNull] ClassDef classDef)
     {
         mermaidScript.AppendLine($"  class {classDef.Name}");
-        classes.Add(classDef);
 
-        return base.VisitClassDef(classDef);
+        if (classDef.IsStructure)
+            structures.Add(classDef);
+        else
+            classes.Add(classDef);
+
+        return DefaultResult;
     }
 
     public override object? VisitAssociationDef([NotNull] AssociationDef associationDef)

--- a/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
+++ b/language-server/src/Geowerkstatt.Interlis.LanguageServer/Visitors/DiagramDocumentVisitor.cs
@@ -78,9 +78,18 @@ internal class DiagramDocumentVisitor : Interlis24AstBaseVisitor<object?>
         {
             var min = card.Min ?? 0;
             var max = card.Max ?? 0;
-            bracket = min == max
-                ? $"[{min}]"
-                : $"[{min}..{max}]";
+            if (min == 1 && max == 1)
+            {
+                bracket = "";
+            }
+            else if (min == max)
+            {
+                bracket = $"[{min}]";
+            }
+            else
+            {
+                bracket = $"[{min}..{max}]";
+            }
         }
 
         var typeName = VisitTypeDefInternal(attributeDef.TypeDef);

--- a/src/assets/webview.css
+++ b/src/assets/webview.css
@@ -16,6 +16,7 @@ body {
 #mermaid-graph {
     flex: 1;
     display: flex;
+    padding: 1rem;
     justify-content: center;
     align-items: center;
     touch-action: none;
@@ -37,8 +38,7 @@ body {
     box-sizing: border-box;
     background: white;
     position: relative;
-    border-top-left-radius: 0.75rem;
-    border-top-right-radius: 0.75rem;
+    border-radius: 0.75rem;
     overflow: hidden;
 }
 
@@ -60,7 +60,7 @@ body {
 
 .actions {
     display: flex;
-    padding: 1rem;
+    padding: 1rem 1rem 0 1rem;
     justify-content: center;
     align-items: center;
     gap: 1rem;
@@ -101,29 +101,29 @@ body {
 
     position: absolute;
     z-index: 99;
-    bottom: 1rem;
-    right: 1rem;
+    bottom: 2rem;
+    right: 2rem;
 
     cursor: pointer;
 
     font-size: 2rem;
     font-weight: bold;
 
-    background-color: #747474;
-    color: white;
+    background-color: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
 }
 
 .help-button:hover {
-    background-color: #AEAEAE;
-    border-color: #AEAEAE;
+    background-color: var(--vscode-button-hoverBackground);
+    border-color:var(--vscode-button-hoverBackground);
 }
 
 .button {
-    background-color: #747474;
-    border: 1px solid #747474;
+    background-color: var(--vscode-button-background);
+    border: 1px solid var(--vscode-button-background);
     border-radius: 4px;
     box-sizing: border-box;
-    color: #FFFFFF;
+    color: var(--vscode-button-foreground);
     cursor: pointer;
     font-family: Graphik, -apple-system, system-ui, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
     font-size: 14px;
@@ -149,11 +149,11 @@ body {
 }
 
 .button:hover {
-    background-color: #AEAEAE;
-    border-color: #AEAEAE;
+    background-color: var(--vscode-button-hoverBackground);
+    border-color: var(--vscode-button-hoverBackground);
 }
 
 .button:active {
-    background-color: #AEAEAE;
-    border-color: #AEAEAE;
+    background-color: var(--vscode-button-hoverBackground);
+    border-color: var(--vscode-button-hoverBackground);
 }

--- a/src/assets/webview.html
+++ b/src/assets/webview.html
@@ -12,6 +12,7 @@
 <div class="actions">
   <button class="button" id="download-svg">Download SVG</button>
   <button class="button" id="copy-code">Copy Mermaid Code</button>
+  <button class="button" id="orientation-button">Orientation: LR</button>
 </div>
 
 <div class="diagram-container">

--- a/src/assets/webview.ts
+++ b/src/assets/webview.ts
@@ -274,8 +274,13 @@ const directions = ["LR", "TB"] as const;
   }
 
   function postWebviewLoaded(): void {
-    const vscode = acquireVsCodeApi();
     vscode.postMessage({ type: "webviewLoaded" });
+  }
+
+  function handleOrientationChange(): void {
+    directionIndex = (directionIndex + 1) % directions.length;
+    orientButton.textContent = "Orientation: " + directions[directionIndex];
+    vscode.postMessage({ type: "orientation", orientation: directions[directionIndex] });
   }
 
   function attachEvents(): void {
@@ -289,6 +294,7 @@ const directions = ["LR", "TB"] as const;
     helpButton.addEventListener("click", handleHelpOpen);
     downloadButton.addEventListener("click", handleDownload);
     closeHelpButton.addEventListener("click", handleHelpClose);
+    orientButton.addEventListener("click", handleOrientationChange);
   }
 
   function init(): void {

--- a/src/assets/webview.ts
+++ b/src/assets/webview.ts
@@ -15,11 +15,16 @@ interface WebviewMessage {
   type: "update";
   text: string;
   resetZoom: boolean;
+  orientation: string;
 }
 
 declare const acquireVsCodeApi: () => VSCodeApi;
 
+const directions = ["LR", "TB"] as const;
+
 (() => {
+  const vscode = acquireVsCodeApi();
+
   // ---- State ----
   let mermaidInitialized = false;
   let lastMermaidCode = "";
@@ -28,11 +33,13 @@ declare const acquireVsCodeApi: () => VSCodeApi;
   let zoomLevel = 1;
   let isPanning = false;
   let panStart = { x: 0, y: 0 };
+  let directionIndex = 0;
 
   // ---- DOM Elements ----
   const container = document.getElementById("mermaid-graph") as HTMLDivElement;
   const downloadButton = document.getElementById("download-svg") as HTMLButtonElement;
   const copyButton = document.getElementById("copy-code") as HTMLButtonElement;
+  const orientButton = document.getElementById("orientation-button") as HTMLButtonElement;
   const helpOverlay = document.getElementById("help-overlay") as HTMLDivElement;
   const helpButton = document.getElementById("help-button") as HTMLButtonElement;
   const closeHelpButton = document.getElementById("close-help") as HTMLButtonElement;

--- a/src/assets/webview.ts
+++ b/src/assets/webview.ts
@@ -81,7 +81,8 @@ declare const acquireVsCodeApi: () => VSCodeApi;
     }
     mermaid.initialize({
       startOnLoad: false,
-      theme: "forest",
+      theme: "neutral",
+      themeCSS: ".classGroup .methods { display: none; }",
       flowchart: { curve: "basis", nodeSpacing: 50, rankSpacing: 50 },
       securityLevel: "strict",
     });
@@ -158,7 +159,7 @@ declare const acquireVsCodeApi: () => VSCodeApi;
     const svgY = currentViewBox.y + (mouseY / rect.height) * currentViewBox.h;
 
     const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
-    const newZoom = Math.min(5, Math.max(0.2, zoomLevel * factor));
+    const newZoom = Math.min(15, Math.max(0.2, zoomLevel * factor));
     if (newZoom === zoomLevel) return;
 
     const newW = originalViewBox.w / newZoom;

--- a/src/diagramPanel.ts
+++ b/src/diagramPanel.ts
@@ -28,7 +28,7 @@ async function requestDiagram(uri: string): Promise<string> {
   try {
     const result = await getLanguageClient().sendRequest(ExecuteCommandRequest.type, {
       command: "generateDiagram",
-      arguments: [{ uri }],
+      arguments: [{ uri, orientation }],
     });
     return result ?? "";
   } catch (err) {
@@ -77,12 +77,19 @@ function revealDiagramPanelInternal(context: vscode.ExtensionContext) {
         const editor = vscode.window.activeTextEditor;
 
         if (editor?.document.languageId === "INTERLIS2") {
-          const uri = editor.document.uri.toString();
-          requestDiagram(uri).then((mermaidDsl) => {
+          currentIliUri = editor.document.uri.toString();
+          orientation = message?.orientation || "LR";
+          requestDiagram(currentIliUri).then((mermaidDsl) => {
             lastSentMermaidDsl = mermaidDsl;
             diagramPanel?.webview.postMessage({ type: "update", text: mermaidDsl, resetZoom: true });
           });
         }
+      } else if (message.type === "orientation" && currentIliUri) {
+        orientation = message?.orientation || "LR";
+        requestDiagram(currentIliUri).then((mermaidDsl) => {
+          lastSentMermaidDsl = mermaidDsl;
+          diagramPanel?.webview.postMessage({ type: "update", text: mermaidDsl, resetZoom: true });
+        });
       } else {
         console.warn(`Ignoring unknown message type from webview: ${message.type}`);
       }
@@ -187,8 +194,8 @@ export function initializeDiagramPanel(context: vscode.ExtensionContext) {
         return;
       }
 
-      const uri = editor.document.uri.toString();
-      const mermaidDsl = await requestDiagram(uri);
+      currentIliUri = editor.document.uri.toString();
+      const mermaidDsl = await requestDiagram(currentIliUri);
       postMessage("update", mermaidDsl, mermaidDsl !== lastSentMermaidDsl);
       lastSentMermaidDsl = mermaidDsl;
     }),

--- a/src/diagramPanel.ts
+++ b/src/diagramPanel.ts
@@ -78,14 +78,14 @@ function revealDiagramPanelInternal(context: vscode.ExtensionContext) {
 
         if (editor?.document.languageId === "INTERLIS2") {
           currentIliUri = editor.document.uri.toString();
-          orientation = message?.orientation || "LR";
+          orientation = message.orientation || "LR";
           requestDiagram(currentIliUri).then((mermaidDsl) => {
             lastSentMermaidDsl = mermaidDsl;
             diagramPanel?.webview.postMessage({ type: "update", text: mermaidDsl, resetZoom: true });
           });
         }
       } else if (message.type === "orientation" && currentIliUri) {
-        orientation = message?.orientation || "LR";
+        orientation = message.orientation || "LR";
         requestDiagram(currentIliUri).then((mermaidDsl) => {
           lastSentMermaidDsl = mermaidDsl;
           diagramPanel?.webview.postMessage({ type: "update", text: mermaidDsl, resetZoom: true });

--- a/src/diagramPanel.ts
+++ b/src/diagramPanel.ts
@@ -13,6 +13,8 @@ let hasUserClosedPanel = false;
 let isAutoClosing = false;
 let closeTimer: NodeJS.Timeout | undefined;
 let lastSentMermaidDsl: string | undefined;
+let orientation = "LR";
+let currentIliUri: string | undefined;
 
 function autoClosePanel() {
   if (diagramPanel) {


### PR DESCRIPTION
## Additions

- Added orientation button to the webview. Hopefully it's not a visual overload, perhaps the button could be moved elsewhere. The idea behind the button is that some diagrams really grow vertically or horizontally. By switching the orientation of the mermaid code, the layout of the diagram can improve. It's not a perfect fix, but it helps with models that have a lot of classes in a single topic.

## Changes

- Reworked the visitor logic quite a bit. Associations didn't appear correctly, the order of the attribute names and types wasn't as expected, and other quirks of mermaid and how it interprets certain names or types have been handled (for example, since we're creating an UML, any attribute name that had "( )" was interpreted to be a method signature, causing inconsistent diagram design). The visitor now in a first step gathers all elements that can be rendered, and then in a second step actually generates the mermaid code at the end. Maybe makes the code also easier to digest visually but that's up for debate.

- Adjusted the test suite for the refactored visitor.

- Adjusted the design of the extension to make the diagrams a more neutral color, and also have the extension itself inherit theme colors from VSC directly. That way we have a more coheisve, professional looking product.

